### PR TITLE
Minor changes to allow usage of plugin with the IPv6 standard.

### DIFF
--- a/csharp/SSEtoRserve/App.config
+++ b/csharp/SSEtoRserve/App.config
@@ -14,7 +14,7 @@
                 <value>50051</value>
             </setting>
             <setting name="grpcHost" serializeAs="String">
-                <value>localhost</value>   <!-- Set to 0.0.0.0 to make it reachable from the outside world -->
+                <value>localhost</value>   <!-- Set to 0.0.0.0 (or [::] for IPv6) to make it reachable from the outside world -->
             </setting>
             <setting name="rserveHost" serializeAs="String">
                 <value>127.0.0.1</value>

--- a/csharp/SSEtoRserve/Program.cs
+++ b/csharp/SSEtoRserve/Program.cs
@@ -17,7 +17,7 @@ namespace SSEtoRserve
             {
                 var grpcHost = Convert.ToString(Properties.Settings.Default.grpcHost ?? "localhost");
                 int grpcPort = Convert.ToInt32(Properties.Settings.Default.grpcPort ?? "50051");
-                var rserveHost = IPAddress.Parse(Properties.Settings.Default.rserveHost ?? "127.0.0.1");
+                var rserveHost = Convert.ToString(Properties.Settings.Default.rserveHost ?? "127.0.0.1");
                 int rservePort = Convert.ToInt32(Properties.Settings.Default.rservePort ?? "6311");
                 var rserveUser = Convert.ToString(Properties.Settings.Default.rserveUser ?? "");
                 var rservePassword = Convert.ToString(Properties.Settings.Default.rservePassword ?? "");


### PR DESCRIPTION
Changing how we parse rserveHost from the config file and add
a hint to the config file on how to use an IPv6 address for grpcHost.